### PR TITLE
Add the group paramter to the monitor type

### DIFF
--- a/docs/resources/heartbeat_monitor.md
+++ b/docs/resources/heartbeat_monitor.md
@@ -33,6 +33,7 @@ resource "cronitor_heartbeat_monitor" "this" {
 - `environments` (List of String) The environments the monitor runs in
 - `failure_tolerance` (Number) The number of times the monitor can fail before triggering an alert
 - `grace_seconds` (Number) The number of seconds to wait after failure before triggering an alert
+- `group` (String) The group the monitor belongs to
 - `notify` (List of String) Where the alerts are sent when a failure occurs
 - `paused` (Boolean) Whether the monitor is paused
 - `realert_interval` (String) The interval that alerts are re-sent at

--- a/docs/resources/http_monitor.md
+++ b/docs/resources/http_monitor.md
@@ -65,6 +65,7 @@ resource "cronitor_http_monitor" "this" {
 - `failure_tolerance` (Number) The number of times the monitor can fail before triggering an alert
 - `follow_redirects` (Boolean) Whether to follow redirects of the response
 - `grace_seconds` (Number) The number of seconds to wait after failure before triggering an alert
+- `group` (String) The group the monitor belongs to
 - `headers` (Map of String) The headers sent with the request
 - `notify` (List of String) Where the alerts are sent when a failure occurs
 - `paused` (Boolean) Whether the monitor is paused

--- a/internal/provider/http_monitor_resource.go
+++ b/internal/provider/http_monitor_resource.go
@@ -172,6 +172,10 @@ func (r *HttpMonitorResource) Schema(ctx context.Context, req resource.SchemaReq
 				Computed:            true,
 				Default:             listdefault.StaticValue(types.ListValueMust(types.StringType, []attr.Value{types.StringValue("production")})),
 			},
+			"group": schema.StringAttribute{
+				MarkdownDescription: "The group the monitor belongs to",
+				Optional:            true,
+			},
 		},
 	}
 }
@@ -211,7 +215,7 @@ func (r *HttpMonitorResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	data.Key = types.StringValue(monitor.Key)
+	data.Key = types.StringValue(*monitor.Key)
 
 	// Write logs using the tflog package
 	// Documentation: https://terraform.io/plugin/log
@@ -263,7 +267,7 @@ func (r *HttpMonitorResource) Update(ctx context.Context, req resource.UpdateReq
 	}
 
 	upd := httpToMonitorRequest(plan)
-	upd.Key = state.Key.ValueString()
+	upd.Key = state.Key.ValueStringPointer()
 	monitor, err := r.client.UpdateMonitor(ctx, upd)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to update http monitor", err.Error())

--- a/internal/provider/types.go
+++ b/internal/provider/types.go
@@ -25,6 +25,7 @@ type BaseMonitorModel struct {
 	Timezone          types.String `tfsdk:"timezone"`
 	Tags              types.List   `tfsdk:"tags"`
 	Environments      types.List   `tfsdk:"environments"`
+	Group             types.String `tfsdk:"group"`
 }
 
 type HttpMonitorModel struct {
@@ -98,7 +99,7 @@ func toStringMap(in types.Map) map[string]string {
 func toHttpMonitor(m *cronitor.Monitor) HttpMonitorModel {
 	out := HttpMonitorModel{
 		BaseMonitorModel: BaseMonitorModel{
-			Key:             types.StringValue(m.Key),
+			Key:             types.StringValue(*m.Key),
 			Name:            types.StringValue(m.Name),
 			Disabled:        types.BoolValue(m.Disabled),
 			Paused:          types.BoolValue(m.Paused),
@@ -131,6 +132,9 @@ func toHttpMonitor(m *cronitor.Monitor) HttpMonitorModel {
 	}
 	if m.GraceSeconds != nil {
 		out.GraceSeconds = types.Int32Value(int32(*m.GraceSeconds))
+	}
+	if m.Group != nil {
+		out.Group = types.StringValue(*m.Group)
 	}
 
 	if len(m.Request.Headers) > 0 {
@@ -191,6 +195,10 @@ func httpToMonitorRequest(data HttpMonitorModel) *cronitor.Monitor {
 		tz := data.Timezone.ValueString()
 		out.Timezone = &tz
 	}
+	if data.Group.ValueString() != "" {
+		grp := data.Group.ValueString()
+		out.Group = &grp
+	}
 
 	return out
 }
@@ -198,7 +206,7 @@ func httpToMonitorRequest(data HttpMonitorModel) *cronitor.Monitor {
 func toHeartbeatMonitor(m *cronitor.Monitor) HeartbeatMonitorModel {
 	out := HeartbeatMonitorModel{
 		BaseMonitorModel: BaseMonitorModel{
-			Key:             types.StringValue(m.Key),
+			Key:             types.StringValue(*m.Key),
 			Name:            types.StringValue(m.Name),
 			Disabled:        types.BoolValue(m.Disabled),
 			Paused:          types.BoolValue(m.Paused),
@@ -221,6 +229,9 @@ func toHeartbeatMonitor(m *cronitor.Monitor) HeartbeatMonitorModel {
 	}
 	if m.GraceSeconds != nil {
 		out.GraceSeconds = types.Int32Value(int32(*m.GraceSeconds))
+	}
+	if m.Group != nil {
+		out.Group = types.StringValue(*m.Group)
 	}
 
 	return out
@@ -254,6 +265,10 @@ func heartbeatToMonitorRequest(data HeartbeatMonitorModel) *cronitor.Monitor {
 	if data.Timezone.ValueString() != "" {
 		tz := data.Timezone.ValueString()
 		out.Timezone = &tz
+	}
+	if data.Group.ValueString() != "" {
+		grp := data.Group.ValueString()
+		out.Group = &grp
 	}
 
 	return out

--- a/pkg/cronitor/client.go
+++ b/pkg/cronitor/client.go
@@ -103,14 +103,14 @@ func (c *Client) CreateMonitor(ctx context.Context, monitor *Monitor) (*Monitor,
 		return nil, fmt.Errorf("failed to unmarshal json response: %w", err)
 	}
 
-	return c.GetMonitor(ctx, mon.Key)
+	return c.GetMonitor(ctx, *mon.Key)
 }
 
 func (c *Client) UpdateMonitor(ctx context.Context, monitor *Monitor) (*Monitor, error) {
-	if monitor.Key == "" {
+	if monitor.Key == nil {
 		return nil, errors.New("cannot update monitor with empty key")
 	}
-	req, err := c.request(ctx, http.MethodPut, fmt.Sprintf("/api/monitors/%s", monitor.Key), monitor)
+	req, err := c.request(ctx, http.MethodPut, fmt.Sprintf("/api/monitors/%s", *monitor.Key), monitor)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build update request: %w", err)
 	}
@@ -129,7 +129,7 @@ func (c *Client) UpdateMonitor(ctx context.Context, monitor *Monitor) (*Monitor,
 		return nil, fmt.Errorf("failed to update monitor, code %d, response %s", resp.StatusCode, string(body))
 	}
 
-	return c.GetMonitor(ctx, monitor.Key)
+	return c.GetMonitor(ctx, *monitor.Key)
 }
 
 func (c *Client) DeleteMonitor(ctx context.Context, id string) error {

--- a/pkg/cronitor/types.go
+++ b/pkg/cronitor/types.go
@@ -21,7 +21,7 @@ type Monitor struct {
 	FailureTolerance  *int     `json:"failure_tolerance,omitempty"`
 	GraceSeconds      *int     `json:"grace_seconds,omitempty"`
 	Group             *string  `json:"group,omitempty"`
-	Key               string   `json:"key"`
+	Key               *string  `json:"key,omitempty"`
 	Notify            []string `json:"notify"`
 	Paused            bool     `json:"paused"`
 	Platform          string   `json:"platform"`


### PR DESCRIPTION
The API supports this, so add it as a field to the provider.

Also while doing this is found some other bugs so I fixed them.

- New resources could not be created as it send an empty string for key
  - Updated this to be a pointer to a string so we can create the resource and rely on the returned value
- Fix issue with environment field on heartbeat monitors as they cannot be added this way