### PR TITLE
[PLAT-3218] Add environments support to notification lists and environment resource

### DIFF
--- a/internal/provider/environment_resource.go
+++ b/internal/provider/environment_resource.go
@@ -1,0 +1,165 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/henrywhitaker3/terraform-provider-cronitor/pkg/cronitor"
+)
+
+var _ resource.Resource = &EnvironmentResource{}
+var _ resource.ResourceWithImportState = &EnvironmentResource{}
+
+func NewEnvironmentResource() resource.Resource {
+	return &EnvironmentResource{}
+}
+
+type EnvironmentResource struct {
+	client *cronitor.Client
+}
+
+func (r *EnvironmentResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_environment"
+}
+
+func (r *EnvironmentResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Environment resource",
+
+		Attributes: map[string]schema.Attribute{
+			"key": schema.StringAttribute{
+				MarkdownDescription: "The environment key used as its identifier",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"name": schema.StringAttribute{
+				MarkdownDescription: "The environment display name",
+				Required:            true,
+			},
+			"with_alerts": schema.BoolAttribute{
+				MarkdownDescription: "Whether alerts are enabled for this environment",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+			},
+		},
+	}
+}
+
+func (r *EnvironmentResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*cronitor.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *cronitor.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.client = client
+}
+
+func (r *EnvironmentResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data EnvironmentModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	env, err := r.client.CreateEnvironment(ctx, &cronitor.Environment{
+		Key:        data.Key.ValueString(),
+		Name:       data.Name.ValueString(),
+		WithAlerts: data.WithAlerts.ValueBool(),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("failed to create environment", err.Error())
+		return
+	}
+
+	data.Key = types.StringValue(env.Key)
+	data.Name = types.StringValue(env.Name)
+	data.WithAlerts = types.BoolValue(env.WithAlerts)
+
+	tflog.Trace(ctx, "created an environment")
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *EnvironmentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data EnvironmentModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	env, err := r.client.GetEnvironment(ctx, data.Key.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("failed to get environment from api", err.Error())
+		return
+	}
+
+	data.Key = types.StringValue(env.Key)
+	data.Name = types.StringValue(env.Name)
+	data.WithAlerts = types.BoolValue(env.WithAlerts)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *EnvironmentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan EnvironmentModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	env, err := r.client.UpdateEnvironment(ctx, &cronitor.Environment{
+		Key:        plan.Key.ValueString(),
+		Name:       plan.Name.ValueString(),
+		WithAlerts: plan.WithAlerts.ValueBool(),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("failed to update environment", err.Error())
+		return
+	}
+
+	plan.Key = types.StringValue(env.Key)
+	plan.Name = types.StringValue(env.Name)
+	plan.WithAlerts = types.BoolValue(env.WithAlerts)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *EnvironmentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data EnvironmentModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.client.DeleteEnvironment(ctx, data.Key.ValueString()); err != nil {
+		resp.Diagnostics.AddError("failed to delete environment", err.Error())
+		return
+	}
+}
+
+func (r *EnvironmentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("key"), req, resp)
+}

--- a/internal/provider/notification_list_data_source.go
+++ b/internal/provider/notification_list_data_source.go
@@ -68,6 +68,11 @@ func (n *NotificationListDataSource) Schema(ctx context.Context, req datasource.
 				MarkdownDescription: "The webhook urls to send notifications to",
 				Computed:            true,
 			},
+			"environments": schema.ListAttribute{
+				ElementType:         types.StringType,
+				MarkdownDescription: "The environments this notification list applies to",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/notification_list_resource.go
+++ b/internal/provider/notification_list_resource.go
@@ -87,6 +87,13 @@ func (r *NotificationListResource) Schema(ctx context.Context, req resource.Sche
 				Computed:            true,
 				Default:             listdefault.StaticValue(types.ListNull(types.StringType)),
 			},
+			"environments": schema.ListAttribute{
+				ElementType:         types.StringType,
+				MarkdownDescription: "The environments this notification list applies to",
+				Optional:            true,
+				Computed:            true,
+				Default:             listdefault.StaticValue(types.ListNull(types.StringType)),
+			},
 		},
 	}
 }
@@ -159,6 +166,7 @@ func (r *NotificationListResource) Read(ctx context.Context, req resource.ReadRe
 	fixSliceOrder(state.Notifications.Pagerduty, &list.Notifications.Pagerduty)
 	fixSliceOrder(state.Notifications.Phones, &list.Notifications.Phones)
 	fixSliceOrder(state.Notifications.Webhooks, &list.Notifications.Webhooks)
+	fixSliceOrder(state.Environments, &list.Environments)
 
 	data = toNotificationList(list)
 
@@ -190,6 +198,7 @@ func (r *NotificationListResource) Update(ctx context.Context, req resource.Upda
 	fixSliceOrder(upd.Notifications.Pagerduty, &list.Notifications.Pagerduty)
 	fixSliceOrder(upd.Notifications.Phones, &list.Notifications.Phones)
 	fixSliceOrder(upd.Notifications.Webhooks, &list.Notifications.Webhooks)
+	fixSliceOrder(upd.Environments, &list.Environments)
 
 	state = toNotificationList(list)
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -78,8 +78,9 @@ func (p *CronitorProvider) Configure(ctx context.Context, req provider.Configure
 
 func (p *CronitorProvider) Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
-		NewHttpMonitorResource,
+		NewEnvironmentResource,
 		NewHeartbeatMonitorResource,
+		NewHttpMonitorResource,
 		NewNotificationListResource,
 	}
 }

--- a/internal/provider/types.go
+++ b/internal/provider/types.go
@@ -48,14 +48,21 @@ type HeartbeatMonitorModel struct {
 	TelemetryUrl types.String `tfsdk:"telemetry_url"`
 }
 
+type EnvironmentModel struct {
+	Key        types.String `tfsdk:"key"`
+	Name       types.String `tfsdk:"name"`
+	WithAlerts types.Bool   `tfsdk:"with_alerts"`
+}
+
 type NotificationListModel struct {
-	Name      types.String `tfsdk:"name"`
-	Key       types.String `tfsdk:"key"`
-	Emails    types.List   `tfsdk:"emails"`
-	Slack     types.List   `tfsdk:"slack"`
-	Pagerduty types.List   `tfsdk:"pagerduty"`
-	Phones    types.List   `tfsdk:"phones"`
-	Webhooks  types.List   `tfsdk:"webhooks"`
+	Name         types.String `tfsdk:"name"`
+	Key          types.String `tfsdk:"key"`
+	Emails       types.List   `tfsdk:"emails"`
+	Slack        types.List   `tfsdk:"slack"`
+	Pagerduty    types.List   `tfsdk:"pagerduty"`
+	Phones       types.List   `tfsdk:"phones"`
+	Webhooks     types.List   `tfsdk:"webhooks"`
+	Environments types.List   `tfsdk:"environments"`
 }
 
 func processSlice[T, U any](in []T, t attr.Type, c func(T) U) types.List {
@@ -261,13 +268,14 @@ func heartbeatToMonitorRequest(data HeartbeatMonitorModel) *cronitor.Monitor {
 
 func toNotificationList(l *cronitor.NotificationList) NotificationListModel {
 	return NotificationListModel{
-		Name:      types.StringValue(l.Name),
-		Key:       types.StringValue(l.Key),
-		Emails:    stringSlice(l.Notifications.Emails),
-		Slack:     stringSlice(l.Notifications.Slack),
-		Pagerduty: stringSlice(l.Notifications.Pagerduty),
-		Phones:    stringSlice(l.Notifications.Phones),
-		Webhooks:  stringSlice(l.Notifications.Webhooks),
+		Name:         types.StringValue(l.Name),
+		Key:          types.StringValue(l.Key),
+		Emails:       stringSlice(l.Notifications.Emails),
+		Slack:        stringSlice(l.Notifications.Slack),
+		Pagerduty:    stringSlice(l.Notifications.Pagerduty),
+		Phones:       stringSlice(l.Notifications.Phones),
+		Webhooks:     stringSlice(l.Notifications.Webhooks),
+		Environments: stringSlice(l.Environments),
 	}
 }
 
@@ -282,6 +290,7 @@ func listToListRequest(data NotificationListModel) *cronitor.NotificationList {
 			Phones:    toStringSlice(data.Phones),
 			Webhooks:  toStringSlice(data.Webhooks),
 		},
+		Environments: toStringSlice(data.Environments),
 	}
 }
 

--- a/pkg/cronitor/client.go
+++ b/pkg/cronitor/client.go
@@ -253,6 +253,108 @@ func (c *Client) DeleteNotificationList(ctx context.Context, list *NotificationL
 	return nil
 }
 
+func (c *Client) GetEnvironment(ctx context.Context, key string) (*Environment, error) {
+	req, err := c.request(ctx, http.MethodGet, fmt.Sprintf("/api/environments/%s", key), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build request: %w", err)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get environment: %w", err)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get environment code: %d body: %s", resp.StatusCode, string(body))
+	}
+
+	out := &Environment{}
+	if err := json.Unmarshal(body, out); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response body: %w", err)
+	}
+
+	return out, nil
+}
+
+func (c *Client) CreateEnvironment(ctx context.Context, env *Environment) (*Environment, error) {
+	req, err := c.request(ctx, http.MethodPost, "/api/environments", env)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build request: %w", err)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create environment: %w", err)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("failed to create environment code: %d body: %s", resp.StatusCode, string(body))
+	}
+
+	out := &Environment{}
+	if err := json.Unmarshal(body, out); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response body: %w", err)
+	}
+
+	return out, nil
+}
+
+func (c *Client) UpdateEnvironment(ctx context.Context, env *Environment) (*Environment, error) {
+	req, err := c.request(ctx, http.MethodPut, fmt.Sprintf("/api/environments/%s", env.Key), env)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build request: %w", err)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update environment: %w", err)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to update environment code: %d body: %s", resp.StatusCode, string(body))
+	}
+
+	out := &Environment{}
+	if err := json.Unmarshal(body, out); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response body: %w", err)
+	}
+
+	return out, nil
+}
+
+func (c *Client) DeleteEnvironment(ctx context.Context, key string) error {
+	req, err := c.request(ctx, http.MethodDelete, fmt.Sprintf("/api/environments/%s", key), nil)
+	if err != nil {
+		return fmt.Errorf("failed to build request: %w", err)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to delete environment: %w", err)
+	}
+
+	if resp.StatusCode > 299 {
+		return fmt.Errorf("failed to delete environment, code: %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
 func (c *Client) setCreateDefaults(mon *Monitor) {
 	if mon.RealertInterval == "" {
 		mon.RealertInterval = "every 8 hours"

--- a/pkg/cronitor/types.go
+++ b/pkg/cronitor/types.go
@@ -48,4 +48,11 @@ type NotificationList struct {
 	Name          string        `json:"name"`
 	Key           string        `json:"key"`
 	Notifications Notifications `json:"notifications,omitempty"`
+	Environments  []string      `json:"environments,omitempty"`
+}
+
+type Environment struct {
+	Key        string `json:"key"`
+	Name       string `json:"name"`
+	WithAlerts bool   `json:"with_alerts"`
 }


### PR DESCRIPTION
Adds two features to the Cronitor Terraform provider:

1. **Environments on notification lists** - The `cronitor_notification_list` resource and data source now support an `environments` attribute, allowing notification lists to be scoped to specific environments via Terraform rather than requiring manual UI configuration.

2. **Environment resource** - A new `cronitor_environment` resource with full CRUD support for managing Cronitor environments as code. Supports `key`, `name`, and `with_alerts` attributes, with import via `terraform import cronitor_environment.<name> <key>`.

Both features use the existing Cronitor API endpoints which already support these fields.